### PR TITLE
ACCRM-544-EstDrawdown-falls-on-previous-day

### DIFF
--- a/lib/dba.coffee
+++ b/lib/dba.coffee
@@ -103,9 +103,14 @@ class exports.connection
 			@cacheObj = new exports.cache()
 		@clearLog()
 		@connect(dbh, done)
+		@setPgDateType()
 
 	setName: (@name) -> @
 	getName: -> @name
+
+	setPgDateType: ->
+  		pg.types.setTypeParser 1114, (stringValue) ->
+    		moment.utc(stringValue).toISOString()
 
 	clone: (callback, cache) ->
 		exports.connection.connect @conString, callback, (cache ? @cacheObj)


### PR DESCRIPTION
Overriding the type parser for timestamp without time zone fields