### PR TITLE
Make inotify an optional dependency to enable development on non linux machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ results
 
 npm-debug.log
 .DS_Store
+
+.idea

--- a/lib/api/apiService.coffee
+++ b/lib/api/apiService.coffee
@@ -5,7 +5,12 @@ API application service to fit into the stampede app framework.
 ###
 
 stampede = require '../stampede'
-Inotify = require('inotify').Inotify
+
+try
+	Inotify = require('inotify').Inotify
+catch er
+	Inotify = null
+
 express = require 'express'
 http = require 'http'
 io = require 'socket.io'
@@ -47,7 +52,8 @@ class module.exports extends service
 
 		if app.isDebug() or @getSetting('developerMode', false) is true
 			@devMode = true
-			@inotify = new Inotify()
+			if Inotify
+				@inotify = new Inotify()
 
 	# Called when the service first starts
 	start: (done) ->
@@ -138,7 +144,7 @@ class module.exports extends service
 					# Scan through the handler for routes that can be added to the router
 					for name, route of h when stampede._.isFunction(route)
 						log.debug "Checking potential route #{name} in file #{localPath}"
-						
+
 						# Temporarily instance the route
 						i = new route()
 						if i instanceof stampede.api.handler

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "socket.io-client": "1.x",
     "commander": "2.x",
     "redis": "0.x",
-    "inotify": "1.x",
     "cookie-parser": "1.x",
     "bignumber.js": "1.x",
     "cli-color": "1.x",
     "excel4node": "0.x"
+  },
+  "optionalDependencies": {
+    "inotify": "1.x"
   }
 }


### PR DESCRIPTION
Inotify is linux only and having it as a required dependency makes it impossible to install anything that relies on stampede on Mac to enable code completion. This PR makes it an optional dependency so it will try to install but failure will not bring the whole thing down. 

This should be low impact as it looks like inotify is only used to kill the process if one of the api files changes during development which means there is no harm in it not being present?

Its function can also be replicated in a cross platform way using nodemon or a pm2 watch facilities depending upon the application making use of this module.